### PR TITLE
Bug Fix, Adjustment to Directory Iteration, sfc Support

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,4 +1,4 @@
-import tkinter, os
+import tkinter, os, sys
 from tkinter import ttk
 from tkinter import messagebox
 from remonsterate.remonsterate import remonsterate
@@ -20,16 +20,30 @@ class RemonstrateGUI(tkinter.Frame):
         self.font = "Arial"
         self.font_size = 12
 
-        #Populate the file name lists
+        #Populate the file name lists. Iterates through directories starting at the
+        #   directory containing the exe file. Does not traverse directories past
+        #   the depth specified by walk_distance.
+        walk_distance = 2
+        exe_directory = os.path.abspath(".")
+        exe_directory_level = exe_directory.count(os.path.sep)
         for root, dirs, files in os.walk("."):
-            for file in files:
-                if str(file).endswith(".smc"):
-                    self.rom_files.append(file)
-                elif str(file).endswith(".txt"):
-                    if "images" in str(file):
-                        self.image_files.append(file)
-                    elif "monsters" in str(file):
-                        self.monster_files.append(file)
+            current_walking_directory = os.path.abspath(root)
+            current_directory_level = current_walking_directory.count(os.path.sep)
+            if current_directory_level > exe_directory_level + 2:
+                #del dirs[:] empties the list that os.walk uses to determine what
+                #   directories to walk through, meaning os.walk will move on to
+                #   the next directory. It does NOT delete or modify files on the
+                #   hard drive.
+                del dirs[:] 
+            else:
+                for file_name in files:
+                    if file_name.endswith(".smc"):
+                        self.rom_files.append(os.path.join(root, file_name))
+                    elif file_name.endswith(".txt"):
+                        if "images" in file_name:
+                            self.image_files.append(os.path.join(root, file_name))
+                        elif "monsters" in file_name:
+                            self.monster_files.append(os.path.join(root, file_name))
 
         #Row 1: ROM File Information
         widget = tkinter.Label(

--- a/run.py
+++ b/run.py
@@ -37,7 +37,7 @@ class RemonstrateGUI(tkinter.Frame):
                 del dirs[:] 
             else:
                 for file_name in files:
-                    if file_name.endswith(".smc"):
+                    if file_name.endswith(".smc") or file_name.endswith(".sfc"):
                         self.rom_files.append(os.path.join(root, file_name))
                     elif file_name.endswith(".txt"):
                         if "images" in file_name:

--- a/run.py
+++ b/run.py
@@ -1,4 +1,4 @@
-import tkinter, os, sys
+import tkinter, os
 from tkinter import ttk
 from tkinter import messagebox
 from remonsterate.remonsterate import remonsterate


### PR DESCRIPTION
After thinking about the GUI, I realized I had a couple of issues I needed to fix. First was that pathing information was not retrieved during os.walk(), so when randomization was attempted, it would cause a File Not Found error for files in subdirectories. The second was that the unbounded nature of os.walk() could cause problems depending on the directory the the executable file is run in.

After making some changes to the code, I noticed you swapped os.walk() for os.listdir(). This fixes both issues. But it also means remonstrate can only use text and rom files in the same directory as the executable, correct?

Changes:
1) Fixed a File Not Found exception that occurred when files were selected that were in subdirectories. When traversing the directories for valid files, os.walk() now retrieves relative path information. The relative path is also displayed in the Comboboxes.
2) The program now traverses three levels of directories looking for valid files: the directory the executable is in and two levels of subdirectories. This can be adjusted with the walk_distance variable. Previously, os.walk() would continue until all subfolders and files were exhausted, which could potentially scan an entire hard drive partition if somebody were to run remonstrate from a root directory.
3) Added .sfc to the list of extensions os.walk() detects.